### PR TITLE
Update requirements and add ffmpeg as default method in origin_config…

### DIFF
--- a/docs/Origin.md
+++ b/docs/Origin.md
@@ -17,4 +17,5 @@ This varient of fHDHR connects to Ceton TV tuners
 Usage with fHDHR requires:
 
 * a Ceton TV tuner
+* FFMPEG
 

--- a/origin/origin_conf.json
+++ b/origin/origin_conf.json
@@ -28,7 +28,12 @@
                     "config_web": true
                 },
           "tuner_count":{
-                  "value": 3,
+                  "value": 4,
+                  "config_file": true,
+                  "config_web": true
+                },
+          "stream_type":{
+                  "value": "ffmpeg",
                   "config_file": true,
                   "config_web": true
                 },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-base64
 flask
 gevent
 image


### PR DESCRIPTION
Removed base64 and added ffmpeg to requirements
Set ffmpeg to be the default streaming method in origin_conf.json